### PR TITLE
docs(themes): Add a demo for each official theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ The list of available themes will be printed out to the standard output. By defa
 By now, you probably only have the `default` theme available, the `postmanerator themes get` command allows you download a new existing theme.
 You can either specify the name of one of the themes that are indexed in the [official themes repository](https://github.com/aubm/postmanerator-themes), or either specify a full URL pointing to git repository. Moreover the `-local-name` option allows you to change the name of your local copy of the theme. Please see the following examples.
 
+Official themes previews are accessible here :
+- [default](http://aubm.github.io/Books-API/)
+- [hu](<< UPDATE THIS TO RAW GIT URL >>)
+- [markdown](<< UPDATE THIS TO RAW GIT URL >>)
+
 ```bash
 postmanerator themes get markdown # will down the theme 'markdown' and copy it under your local themes directory in a folder named 'markdown'
 postmanerator -local-name="my-markdown" themes get markdown # will down the theme 'markdown' and copy it under your local themes directory in a folder named 'my-markdown'

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ You can either specify the name of one of the themes that are indexed in the [of
 
 Official themes previews are accessible here :
 - [default](http://aubm.github.io/Books-API/)
-- [hu](<< UPDATE THIS TO RAW GIT URL >>)
-- [markdown](<< UPDATE THIS TO RAW GIT URL >>)
+- [hu](https://cdn.rawgit.com/antoinerey/postmanerator/0082d47f499219de3243e76f8fe1332bfa60b585/demos/hu.html)
+- [markdown](https://cdn.rawgit.com/antoinerey/postmanerator/0082d47f499219de3243e76f8fe1332bfa60b585/demos/markdown.html)
 
 ```bash
 postmanerator themes get markdown # will down the theme 'markdown' and copy it under your local themes directory in a folder named 'markdown'

--- a/demos/default.html
+++ b/demos/default.html
@@ -1,0 +1,699 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cats API</title>
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/styles/darkula.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+    <style>body {
+    position: relative;
+}
+
+h1 {
+    margin-top: 5px;
+}
+
+h1, h2, h3, h4 {
+    color: #2b2b2b;
+}
+
+h2:after {
+    content: ' ';
+}
+
+h5 {
+    font-weight: bold;
+}
+
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+    display: none;
+    position: absolute;
+    margin-left: 8px;
+}
+
+h1:hover a, h2:hover a, h3:hover a, h4:hover a, h5:hover a, h6:hover a {
+    color: #a5a5a5;
+    display: initial;
+}
+
+.nav.nav-tabs > li > a {
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+.tab-content {
+    padding-top: 8px;
+}
+
+.table {
+    margin-bottom: 8px;
+}
+
+pre {
+    border-radius: 0px;
+    border: none;
+}
+
+pre code {
+    margin: -9.5px;
+}
+
+.request {
+    margin-top: 12px;
+    margin-bottom: 24px;
+}
+
+.response-text-sample {
+    padding: 0px !important;
+}
+
+.response-text-sample pre {
+    margin-bottom: 0px;
+}
+
+
+#sidebar-wrapper {
+    z-index: 1000;
+    position: fixed;
+    left: 250px;
+    width: 250px;
+    height: 100%;
+    margin-left: -250px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    background: #2b2b2b;
+    padding-top: 20px;
+}
+
+#sidebar-wrapper ul {
+    width: 250px;
+}
+
+#sidebar-wrapper ul li {
+    margin-right: 10px;
+}
+
+#sidebar-wrapper ul li a:hover {
+    background: inherit;
+    text-decoration: none;
+}
+
+#sidebar-wrapper ul li a {
+    display: block;
+    color: #ECF0F1;
+    padding: 6px 15px;
+}
+
+#sidebar-wrapper ul li ul {
+    padding-left: 25px;
+}
+
+#sidebar-wrapper ul li ul li a {
+    padding: 1px 0px;
+}
+
+#sidebar-wrapper ul li a:hover,
+#sidebar-wrapper ul li a:focus {
+    color: #e0c46c;
+    border-right: solid 1px #e0c46c;
+}
+
+#sidebar-wrapper ul li.active > a {
+    color: #e0c46c;
+    border-right: solid 3px #e0c46c;
+}
+
+#sidebar-wrapper ul li:not(.active) ul {
+    display: none;
+}
+
+#page-content-wrapper {
+    width: 100%;
+    position: absolute;
+    padding: 15px 15px 15px 250px;
+}
+</style>
+</head>
+<body data-spy="scroll" data-target=".scrollspy">
+<div id="sidebar-wrapper">
+    <div class="scrollspy">
+    <ul id="main-menu" data-spy="affix" class="nav">
+        <li>
+            <a href="#doc-general-notes">General notes</a>
+        </li>
+        
+        <li>
+            <a href="#doc-api-structures">API structures</a>
+            <ul>
+                
+                <li>
+                    <a href="#struct-Dog">Dog</a>
+                </li>
+                
+                <li>
+                    <a href="#struct-Cat">Cat</a>
+                </li>
+                
+            </ul>
+        </li>
+        
+        <li>
+            <a href="#doc-api-detail">API detail</a>
+        </li>
+         
+        <li>
+            <a href="#folder-cats">Cats</a>
+            <ul>
+                 
+                <li>
+                    <a href="#request-cats-create-a-new-cat">Create a new cat</a>
+                </li>
+                  
+                <li>
+                    <a href="#request-cats-get-all-cats">Get all cats</a>
+                </li>
+                  
+                <li>
+                    <a href="#request-cats-get-one-cat">Get one cat</a>
+                </li>
+                  
+                <li>
+                    <a href="#request-cats-delete-one-cat">Delete one cat</a>
+                </li>
+                  
+                <li>
+                    <a href="#request-cats-get-zero-cats">Get zero cats</a>
+                </li>
+                 
+            </ul>
+        </li>
+          
+        <li>
+            <a href="#folder-dogs">Dogs</a>
+            <ul>
+                 
+                <li>
+                    <a href="#request-dogs-get-one-dog">Get one dog</a>
+                </li>
+                 
+            </ul>
+        </li>
+         
+    </ul>
+</div>
+
+</div>
+<div id="page-content-wrapper">
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-12">
+                <h1>Cats API</h1>
+
+                <h2 id="doc-general-notes">
+                    General notes
+                    <a href="#doc-general-notes"><i class="glyphicon glyphicon-link"></i></a>
+                </h2>
+
+                <p>Tu autem, Fanni, quod mihi tantum tribui dicis quantum ego nec adgnosco nec postulo, facis amice; sed, ut mihi videris, non recte iudicas de Catone; aut enim nemo, quod quidem magis credo, aut si quisquam, ille sapiens fuit. Quo modo, ut alia omittam, mortem filii tulit! memineram Paulum, videram Galum, sed hi in pueris, Cato in perfecto et spectato viro.</p>
+
+<p>Novitates autem si spem adferunt, ut tamquam in herbis non fallacibus fructus appareat, non sunt illae quidem repudiandae, vetustas tamen suo loco conservanda; maxima est enim vis vetustatis et consuetudinis. Quin in ipso equo, cuius modo feci mentionem, si nulla res impediat, nemo est, quin eo, quo consuevit, libentius utatur quam intractato et novo. Nec vero in hoc quod est animal, sed in iis etiam quae sunt inanima, consuetudo valet, cum locis ipsis delectemur, montuosis etiam et silvestribus, in quibus diutius commorati sumus.</p>
+
+
+                
+                <h2 id="doc-api-structures">
+                    API structures
+                    <a href="#doc-api-structures"><i class="glyphicon glyphicon-link"></i></a>
+                </h2>
+
+                
+
+                    <h3 id="struct-Dog">
+                        Dog
+                        <a href="#struct-Dog"><i class="glyphicon glyphicon-link"></i></a>
+                    </h3>
+
+                    <p>A greater animal</p>
+
+                    <table class="table table-bordered">
+                    
+                        <tr>
+                            <th>id</th>
+                            <td>int</td>
+                            <td>A unique identifier for the dog</td>
+                        </tr>
+                    
+                        <tr>
+                            <th>color</th>
+                            <td>string</td>
+                            <td>The color of the dog</td>
+                        </tr>
+                    
+                        <tr>
+                            <th>name</th>
+                            <td>string</td>
+                            <td>The name of the dog</td>
+                        </tr>
+                    
+                    </table>
+
+                
+
+                    <h3 id="struct-Cat">
+                        Cat
+                        <a href="#struct-Cat"><i class="glyphicon glyphicon-link"></i></a>
+                    </h3>
+
+                    <p>A great animal</p>
+
+                    <table class="table table-bordered">
+                    
+                        <tr>
+                            <th>id</th>
+                            <td>int</td>
+                            <td>A unique identifier for the cat</td>
+                        </tr>
+                    
+                        <tr>
+                            <th>color</th>
+                            <td>string</td>
+                            <td>The color of the cat</td>
+                        </tr>
+                    
+                        <tr>
+                            <th>name</th>
+                            <td>string</td>
+                            <td>The name of the cat</td>
+                        </tr>
+                    
+                    </table>
+
+                
+
+                
+
+                <h2 id="doc-api-detail">
+                    API detail
+                    <a href="#doc-api-detail"><i class="glyphicon glyphicon-link"></i></a>
+                </h2>
+
+                 
+                <div class="endpoints-group">
+                    <h3 id="folder-cats">
+                        Cats
+                        <a href="#folder-cats"><i class="glyphicon glyphicon-link"></i></a>
+                    </h3>
+
+                    <div><p>Accedebant enim eius asperitati, ubi inminuta vel laesa amplitudo imperii dicebatur, et iracundae suspicionum quantitati proximorum cruentae blanditiae exaggerantium incidentia et dolere inpendio simulantium, si principis periclitetur vita, a cuius salute velut filo pendere statum orbis terrarum fictis vocibus exclamabant.</p>
+
+<p>Quod cum ita sit, paucae domus studiorum seriis cultibus antea celebratae nunc ludibriis ignaviae torpentis exundant, vocali sonu, perflabili tinnitu fidium resultantes. denique pro philosopho cantor et in locum oratoris doctor artium ludicrarum accitur et bybliothecis sepulcrorum ritu in perpetuum clausis organa fabricantur hydraulica, et lyrae ad speciem carpentorum ingentes tibiaeque et histrionici gestus instrumenta non levia.</p>
+</div>
+
+                    
+
+                        
+                        <div class="request">
+
+                            <h4 id="request-cats-create-a-new-cat">
+                                Create a new cat
+                                <a href="#request-cats-create-a-new-cat"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+
+                            <div><p>Quae dum ita struuntur, indicatum est apud Tyrum indumentum regale textum occulte, incertum quo locante vel cuius usibus apparatum. ideoque rector provinciae tunc pater Apollinaris eiusdem nominis ut conscius ductus est aliique congregati sunt ex diversis civitatibus multi, qui atrocium criminum ponderibus urgebantur.</p>
+</div>
+
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    <li role="presentation" class="active"><a href="#request-create-a-new-cat-example-curl" data-toggle="tab">Curl</a></li>
+                                    <li role="presentation"><a href="#request-create-a-new-cat-example-http" data-toggle="tab">HTTP</a></li>
+                                </ul>
+                                <div class="tab-content">
+                                    <div class="tab-pane active" id="request-create-a-new-cat-example-curl">
+                                        <pre><code class="hljs curl">curl -X POST -d '{
+    "name": "Doctor Frankeinstein",
+    "color": "brown"
+}' "http://{{domain}}/api/cats"</code></pre>
+                                    </div>
+                                    <div class="tab-pane" id="request-create-a-new-cat-example-http">
+                                        <pre><code class="hljs http">POST /api/cats HTTP/1.1
+Host: {{domain}}
+
+{
+    "name": "Doctor Frankeinstein",
+    "color": "brown"
+}</code></pre>
+                                    </div>
+                                </div>
+                            </div>
+
+                            
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    
+                                    <li role="presentation" class="active">
+                                        <a href="#request-create-a-new-cat-responses-70cc5991-fbbf-791f-902b-ecfe4b37df35" data-toggle="tab">
+                                            
+                                                Response
+                                            
+                                        </a>
+                                    </li>
+                                    
+                                </ul>
+                                <div class="tab-content">
+                                    
+                                    <div class="tab-pane active" id="request-create-a-new-cat-responses-70cc5991-fbbf-791f-902b-ecfe4b37df35">
+                                        <table class="table table-bordered">
+                                            <tr><th style="width: 20%;">Status</th><td>201 Created</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Length</th><td>0</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Type</th><td>text/plain; charset=utf-8</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Date</th><td>Tue, 23 Feb 2016 16:36:18 GMT</td></tr>
+                                            
+                                            
+                                        </table>
+                                    </div>
+                                    
+                                </div>
+                            </div>
+                            
+
+                            <hr>
+                        </div>
+                        
+
+                    
+
+                        
+                        <div class="request">
+
+                            <h4 id="request-cats-get-all-cats">
+                                Get all cats
+                                <a href="#request-cats-get-all-cats"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+
+                            <div><p>Sed si ille hac tam eximia fortuna propter utilitatem rei publicae frui non properat, ut omnia illa conficiat, quid ego, senator, facere debeo, quem, etiamsi ille aliud vellet, rei publicae consulere oporteret?</p>
+</div>
+
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    <li role="presentation" class="active"><a href="#request-get-all-cats-example-curl" data-toggle="tab">Curl</a></li>
+                                    <li role="presentation"><a href="#request-get-all-cats-example-http" data-toggle="tab">HTTP</a></li>
+                                </ul>
+                                <div class="tab-content">
+                                    <div class="tab-pane active" id="request-get-all-cats-example-curl">
+                                        <pre><code class="hljs curl">curl -X GET "http://{{domain}}/api/cats"</code></pre>
+                                    </div>
+                                    <div class="tab-pane" id="request-get-all-cats-example-http">
+                                        <pre><code class="hljs http">GET /api/cats HTTP/1.1
+Host: {{domain}}</code></pre>
+                                    </div>
+                                </div>
+                            </div>
+
+                            
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    
+                                    <li role="presentation" class="active">
+                                        <a href="#request-get-all-cats-responses-91ee2389-3d6d-a56a-83a9-dbb713a35e7c" data-toggle="tab">
+                                            
+                                                Response
+                                            
+                                        </a>
+                                    </li>
+                                    
+                                </ul>
+                                <div class="tab-content">
+                                    
+                                    <div class="tab-pane active" id="request-get-all-cats-responses-91ee2389-3d6d-a56a-83a9-dbb713a35e7c">
+                                        <table class="table table-bordered">
+                                            <tr><th style="width: 20%;">Status</th><td>200 OK</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Length</th><td>81</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Type</th><td>application/json</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Date</th><td>Tue, 23 Feb 2016 16:36:33 GMT</td></tr>
+                                            
+                                            
+                                                
+                                                <tr><td class="response-text-sample" colspan="2">
+                                                    <pre><code>[
+    {
+        "id": "56cc8a8228a4dbe55ca6e6ec",
+        "name": "Doctor Frankeinstein",
+        "color": "brown"
+    }
+]</code></pre>
+                                                </td></tr>
+                                                
+                                            
+                                        </table>
+                                    </div>
+                                    
+                                </div>
+                            </div>
+                            
+
+                            <hr>
+                        </div>
+                        
+
+                    
+
+                        
+                        <div class="request">
+
+                            <h4 id="request-cats-get-one-cat">
+                                Get one cat
+                                <a href="#request-cats-get-one-cat"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+
+                            <div><p>Ciliciam vero, quae Cydno amni exultat, Tarsus nobilitat, urbs perspicabilis hanc condidisse Perseus memoratur, Iovis filius et Danaes, vel certe ex Aethiopia profectus Sandan quidam nomine vir opulentus et nobilis et Anazarbus auctoris vocabulum referens, et Mopsuestia vatis illius domicilium Mopsi, quem a conmilitio Argonautarum cum aureo vellere direpto redirent, errore abstractum delatumque ad Africae litus mors repentina consumpsit, et ex eo cespite punico tecti manes eius heroici dolorum varietati medentur plerumque sospitales.</p>
+</div>
+
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    <li role="presentation" class="active"><a href="#request-get-one-cat-example-curl" data-toggle="tab">Curl</a></li>
+                                    <li role="presentation"><a href="#request-get-one-cat-example-http" data-toggle="tab">HTTP</a></li>
+                                </ul>
+                                <div class="tab-content">
+                                    <div class="tab-pane active" id="request-get-one-cat-example-curl">
+                                        <pre><code class="hljs curl">curl -X GET "http://{{domain}}/api/cats/{{catId}}"</code></pre>
+                                    </div>
+                                    <div class="tab-pane" id="request-get-one-cat-example-http">
+                                        <pre><code class="hljs http">GET /api/cats/%7B%7BcatId%7D%7D HTTP/1.1
+Host: {{domain}}</code></pre>
+                                    </div>
+                                </div>
+                            </div>
+
+                            
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    
+                                    <li role="presentation" class="active">
+                                        <a href="#request-get-one-cat-responses-09bf9394-41e6-ef09-1868-3cd789ebb020" data-toggle="tab">
+                                            
+                                                Response
+                                            
+                                        </a>
+                                    </li>
+                                    
+                                </ul>
+                                <div class="tab-content">
+                                    
+                                    <div class="tab-pane active" id="request-get-one-cat-responses-09bf9394-41e6-ef09-1868-3cd789ebb020">
+                                        <table class="table table-bordered">
+                                            <tr><th style="width: 20%;">Status</th><td>200 OK</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Length</th><td>79</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Type</th><td>application/json</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Date</th><td>Tue, 23 Feb 2016 16:36:44 GMT</td></tr>
+                                            
+                                            
+                                                
+                                                <tr><td class="response-text-sample" colspan="2">
+                                                    <pre><code>{
+    "id": "56cc8a8228a4dbe55ca6e6ec",
+    "name": "Doctor Frankeinstein",
+    "color": "brown"
+}</code></pre>
+                                                </td></tr>
+                                                
+                                            
+                                        </table>
+                                    </div>
+                                    
+                                </div>
+                            </div>
+                            
+
+                            <hr>
+                        </div>
+                        
+
+                    
+
+                        
+                        <div class="request">
+
+                            <h4 id="request-cats-delete-one-cat">
+                                Delete one cat
+                                <a href="#request-cats-delete-one-cat"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+
+                            <div><p>Homines enim eruditos et sobrios ut infaustos et inutiles vitant, eo quoque accedente quod et nomenclatores adsueti haec et talia venditare, mercede accepta lucris quosdam et prandiis inserunt subditicios ignobiles et obscuros.</p>
+</div>
+
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    <li role="presentation" class="active"><a href="#request-delete-one-cat-example-curl" data-toggle="tab">Curl</a></li>
+                                    <li role="presentation"><a href="#request-delete-one-cat-example-http" data-toggle="tab">HTTP</a></li>
+                                </ul>
+                                <div class="tab-content">
+                                    <div class="tab-pane active" id="request-delete-one-cat-example-curl">
+                                        <pre><code class="hljs curl">curl -X DELETE "http://{{domain}}/api/cats/{{catId}}"</code></pre>
+                                    </div>
+                                    <div class="tab-pane" id="request-delete-one-cat-example-http">
+                                        <pre><code class="hljs http">DELETE /api/cats/%7B%7BcatId%7D%7D HTTP/1.1
+Host: {{domain}}</code></pre>
+                                    </div>
+                                </div>
+                            </div>
+
+                            
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    
+                                    <li role="presentation" class="active">
+                                        <a href="#request-delete-one-cat-responses-a187d805-0564-c12f-7817-c4356dcfc7ba" data-toggle="tab">
+                                            
+                                                Response
+                                            
+                                        </a>
+                                    </li>
+                                    
+                                </ul>
+                                <div class="tab-content">
+                                    
+                                    <div class="tab-pane active" id="request-delete-one-cat-responses-a187d805-0564-c12f-7817-c4356dcfc7ba">
+                                        <table class="table table-bordered">
+                                            <tr><th style="width: 20%;">Status</th><td>204 No Content</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Date</th><td>Tue, 23 Feb 2016 16:36:57 GMT</td></tr>
+                                            
+                                            
+                                        </table>
+                                    </div>
+                                    
+                                </div>
+                            </div>
+                            
+
+                            <hr>
+                        </div>
+                        
+
+                    
+
+                        
+                        <div class="request">
+
+                            <h4 id="request-cats-get-zero-cats">
+                                Get zero cats
+                                <a href="#request-cats-get-zero-cats"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+
+                            <div><p>Quam ob rem cave Catoni anteponas ne istum quidem ipsum, quem Apollo, ut ais, sapientissimum iudicavit; huius enim facta, illius dicta laudantur. De me autem, ut iam cum utroque vestrum loquar, sic habetote.</p>
+</div>
+
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    <li role="presentation" class="active"><a href="#request-get-zero-cats-example-curl" data-toggle="tab">Curl</a></li>
+                                    <li role="presentation"><a href="#request-get-zero-cats-example-http" data-toggle="tab">HTTP</a></li>
+                                </ul>
+                                <div class="tab-content">
+                                    <div class="tab-pane active" id="request-get-zero-cats-example-curl">
+                                        <pre><code class="hljs curl">curl -X GET "http://{{domain}}/api/cats"</code></pre>
+                                    </div>
+                                    <div class="tab-pane" id="request-get-zero-cats-example-http">
+                                        <pre><code class="hljs http">GET /api/cats HTTP/1.1
+Host: {{domain}}</code></pre>
+                                    </div>
+                                </div>
+                            </div>
+
+                            
+
+                            <hr>
+                        </div>
+                        
+
+                    
+
+                </div>
+                  
+                <div class="endpoints-group">
+                    <h3 id="folder-dogs">
+                        Dogs
+                        <a href="#folder-dogs"><i class="glyphicon glyphicon-link"></i></a>
+                    </h3>
+
+                    <div></div>
+
+                    
+
+                        
+                        <div class="request">
+
+                            <h4 id="request-dogs-get-one-dog">
+                                Get one dog
+                                <a href="#request-dogs-get-one-dog"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+
+                            <div><p>Ciliciam vero, quae Cydno amni exultat, Tarsus nobilitat, urbs perspicabilis hanc condidisse Perseus memoratur, Iovis filius et Danaes, vel certe ex Aethiopia profectus Sandan quidam nomine vir opulentus et nobilis et Anazarbus auctoris vocabulum referens, et Mopsuestia vatis illius domicilium Mopsi, quem a conmilitio Argonautarum cum aureo vellere direpto redirent, errore abstractum delatumque ad Africae litus mors repentina consumpsit, et ex eo cespite punico tecti manes eius heroici dolorum varietati medentur plerumque sospitales.</p>
+</div>
+
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    <li role="presentation" class="active"><a href="#request-get-one-dog-example-curl" data-toggle="tab">Curl</a></li>
+                                    <li role="presentation"><a href="#request-get-one-dog-example-http" data-toggle="tab">HTTP</a></li>
+                                </ul>
+                                <div class="tab-content">
+                                    <div class="tab-pane active" id="request-get-one-dog-example-curl">
+                                        <pre><code class="hljs curl">curl -X GET "http://{{domain}}/api/dogs/{{dogId}}"</code></pre>
+                                    </div>
+                                    <div class="tab-pane" id="request-get-one-dog-example-http">
+                                        <pre><code class="hljs http">GET /api/dogs/%7B%7BdogId%7D%7D HTTP/1.1
+Host: {{domain}}</code></pre>
+                                    </div>
+                                </div>
+                            </div>
+
+                            
+
+                            <hr>
+                        </div>
+                        
+
+                    
+
+                </div>
+                 
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-2.2.2.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/demos/hu.html
+++ b/demos/hu.html
@@ -1,0 +1,986 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cats API</title>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300,700,800' rel='stylesheet' type='text/css'>
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/styles/darkula.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+    <style>body {
+    position: relative;
+    font-family: "Open Sans", sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-smoothing: antialiased;
+    line-height: 1.5;
+    transition: linear left 0.1s;
+    background-color: #fefefd;
+    color: #808080;
+}
+
+h1 {
+    margin-top: 5px;
+    text-shadow: 1px 1px 3em #848474;
+    font-weight: bold;
+}
+
+h1, h2, h3, h4 {
+    color: #505050;
+}
+
+h2:after {
+    content: ' ';
+}
+
+h5 {
+    font-weight: bold;
+}
+
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+    display: none;
+    position: absolute;
+    margin-left: 8px;
+}
+
+hr {
+    margin: 0; width: 55%
+}
+
+p, strong, small, code {
+    word-break: break-word !important;
+}
+
+IMG {
+    max-width: 100%;
+}
+.markdown {
+    max-width: 610px;
+    display: inline-block;
+}
+.markdown pre, .doc pre {
+    border-radius: 3px;
+    border: 1px solid #e6e6e6;
+}
+.markdown *[class*="hljs"], .doc code[class*="hljs"], .doc pre *[class*="hljs"] {
+    background-color: #FAFAFA;
+    color: #808080;
+}
+
+
+h1:hover a, h2:hover a, h3:hover a, h4:hover a, h5:hover a, h6:hover a {
+    color: #a5a5a5;
+    display: initial;
+}
+
+.col-md-12 {
+    padding-left: 2em;
+}
+
+.nav.nav-tabs > li > a {
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+.tab-content {
+    padding-top: 8px;
+}
+
+table {
+    margin-top: 8px;
+    margin-bottom: 18px;
+}
+
+td {
+    padding: 5px;
+}
+tr:nth-child(even) {
+    background-color : rgba(0, 0, 0, 0.05);
+}
+
+.clear {
+    clear:both;
+}
+
+
+table pre {
+    max-width: 600px;
+}
+pre {
+    max-width: 610px;
+    border-radius: 0px;
+    border: none;
+}
+
+pre code {
+    margin: -9.5px;
+    font-family: "Courier", sans-serif;
+
+}
+
+#doc-general-notes {
+    font-weight: normal;
+}
+.request {
+    margin-top: 50px;
+    margin-bottom: 24px;
+}
+
+.endpoints-group {
+    margin-top: 100px;
+}
+.response-text-sample {
+    padding: 0px !important;
+}
+
+.response-text-sample pre {
+    margin-bottom: 0px;
+}
+
+
+#sidebar-wrapper {
+    z-index: 1000;
+    position: fixed;
+    left: 250px;
+    width: 250px;
+    height: 100%;
+    margin-left: -250px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    background: #404044;
+    padding-top: 20px;
+}
+
+#sidebar-wrapper ul {
+    width: 260px;
+    list-style: none;
+}
+
+#sidebar-wrapper ul li {
+    margin-right: 10px;
+    font-weight: bold;
+}
+
+#sidebar-wrapper ul li a:hover {
+    background: inherit;
+    text-decoration: none;
+}
+
+#sidebar-wrapper ul li a {
+    display: block;
+    color: #b3b3b3; // #ECF0F1;
+    padding: 6px 15px;
+}
+
+#sidebar-wrapper .icon {
+    color:#b3b3b3;
+}
+
+#sidebar-wrapper .glyphicon-collapse-up {
+    display: none;
+}
+
+#sidebar-wrapper .active .glyphicon-collapse-down {
+    display: none;
+}
+
+#sidebar-wrapper ul li ul {
+    padding-left: 25px;
+}
+
+#sidebar-wrapper ul li ul li {
+    font-weight: normal;
+    font-size: 90%;
+}
+
+#sidebar-wrapper ul li ul li a {
+    padding: 1px 0px;
+}
+
+#sidebar-wrapper ul li a:hover,
+#sidebar-wrapper ul li a:focus {
+    color: #efefef;
+    border-right: solid 1px #efefef;
+}
+
+#sidebar-wrapper ul li.active > a {
+    color: #efefef;
+    border-right: solid 3px #efefef;
+}
+
+#sidebar-wrapper .active .glyphicon-collapse-up {
+    color: #efefef;
+    display: inline-block;
+}
+
+#sidebar-wrapper ul li:not(.active) ul {
+    display: none;
+}
+
+#page-content-wrapper {
+    width: 100%;
+    position: absolute;
+    padding: 15px;
+}
+
+@media (min-width:768px) {
+    #page-content-wrapper {
+        padding-left:250px;
+    }
+}
+
+.markdown H3,  .markdown H2, .markdown H1 {
+    text-transform: uppercase;
+    font-size: 100%;
+}
+
+.panel-body, .tab-content {
+    padding: 0px;
+}
+
+.panel-dark {
+    background-color: #222;
+    border-color: #444;
+}
+
+.panel-dark > .panel-heading {
+    color: #fff;
+    background-color: rgba(255, 255, 255, 0.1);
+    border-color: #444;
+    padding: 4px 8px;
+}
+
+.markdown pre, .doc pre {
+    margin: 0px;
+    min-height: 50px;
+    max-height: 250px;
+}
+
+pre:hover {
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+@media (min-width:768px) {
+    .splitted {
+        background: linear-gradient(90deg, transparent 65%, #3c3c33 35%);
+    }
+}
+
+.main-title {
+    white-space: normal;
+    display: inline-block;
+}
+
+.GET {
+  color: #3eb63e; }
+
+.POST {
+  color: #f5a623; }
+
+.PATCH {
+  color: #666666; }
+
+.PUT {
+  color: #4a90e2; }
+
+.DELETE {
+  color: #ed4b48; }
+
+
+.no-padding  {
+      padding-left: 0 !important;
+}
+</style>
+    <link rel="shortcut icon" type="image/png" href="data:image/ico;base64,AAABAAQAMDAAAAEAIACoJQAARgAAACAgAAABACAAqBAAAO4lAAAYGAAAAQAgAIgJAACWNgAAEBAAAAEAIABoBAAAHkAAACgAAAAwAAAAYAAAAAEAIAAAAAAAgCUAAAAAAAAAAAAAAAAAAAAAAAD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AAFlOQAAZTkAE2U5AHxlOQC1ZTkAumU5ALxlOQCcXTQAA2U5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlOQAAZTkAAGU5AI5lOQC9ZTkAuWU5ALdYMQCGZTkAHmA2AABjOAAB////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AAFlOQAhZTkA22U5AP9lOQD/ZTkA/2U5AP9lOQDRXTQAAGU5AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlOQACZTkAAGU5ALplOQD/ZTkA/2U5AP9mOQD/ZTkA6Fw0ADBlOQAAZTkAAv///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AABlOQCwZTkA/2U5APdlOQD7ZTkA92U5APtlOQCUZjkAAGU5AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlOQADZTkAAGU5AH1lOQD7ZTkA9mU5APxkOAD3ZTkA/2Y5AMdbMwAC////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5ABllOQD3ZTkA/WU5AP5lOQD+ZTkA+mU5AP5lOQBnZDgAAGU5AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlOQACZTkAAGU5AFFlOQD/ZTkA+mU5AP5lOQD/ZTkA/GQ4AP5jOAAr////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AExlOQD/ZTkA/GU5AP9lOQD/ZTkA/GU5AP9lOQA5ZTkAAGU5AAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlOQABZTkAAGU5ACdlOQD8ZTkA/mU5AP5lOQD/ZTkA+2U5AP5lOQBj////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AIdlOQD+ZTkA+mU5AP5lOQD+ZTkA/2U5APBlOQAUZTkAAGU5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZTkAAGU5AAdlOQDiZTkA/2U5AP1lOQD+ZTkA+mU5AP5lOQCf////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AL9lOQD+ZTkA/GU5AP9lOQD8ZTkA/mU5AM9lOQAAZTkAAWU5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlOQAAZTkAAmU5AABlOQC9ZTkA/mU5APtlOQD/ZTkA/WU5AP9lOQDU////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AO5lOQD/ZTkA/mU5AP9lOQD6ZTkA/2U5AKNlOQAAZTkAA2U5AABlOQABZTkAAmU5AAIAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZTkABGU5AABlOQCOZTkA/mU5APllOQD/ZTkA/mU5AP5lOQD5////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AP9lOQD8ZTkA/2U5AP9lOQD5ZTkA/2U5AHdlOQAEZTkABGU5AABlOQAAZTkAAGU5AABlOQAAAAAAAGU5AANlOQAEZTkAAWU5AABlOQAAAAAAAAAAAAAAAAAAZTkAA2U5AABlOQBfZTkA/mU5APplOQD+ZTkA/2U5APtlOQD/ZTkAV////wD///8A////AP///wD///8A////AP///wD///8AAAAAAAAAAAAAAAAAZTkAAGU5AARmOQAAZTkAeWU5AP5lOQD6ZTkA/mU5AP9lOQD7ZTkA/2U5ADVlOQAAZTkAAmU5ABRlOQAmZTkALmU5AChlOQAYZTkAA2U5AABlOQAAZTkAAGU5AANlOQABAAAAAGU5AAAAAAAAZTkAAmU5AABlOQA0ZTkA/2U5AP1lOQD/ZTkA/mU5APplOQD+ZTkAkWY5AABlOQAEZTkAAAAAAAAAAAAAAAAAAP///wD///8AAAAAAAAAAAAAAAAAZTkAAGU5AAJfNgAAZTkAs2U5AP5lOQD7ZTkA/2U5AP9lOQD9ZTkA/2U5AINlOQCZZTkA0mU5AO9lOQD9ZTkA/2U5AP5lOQDyZTkA12U5AKZlOQBgZTkAFmU5AABlOQAAUC0AA2U5AABlOQAAZTkAAGU5AABlOQAQZTkA7GU5AP9lOQD+ZTkA/2U5APxlOQD/ZTkAyVozAABlOQABZTkAAAAAAAAAAAAAAAAAAP///wD///8AAAAAAAAAAAAAAAAAZTkAAGU5AABdNAAMZTkA5GU5AP9lOQD9ZTkA/2U5AP9lOQD/ZTkA/2U5AP9lOQD/ZTkA/2U5AP9lOQD9ZTkA+WU5APxlOQD/ZTkA/2U5AP9lOQD/ZTkA9GU5AJJlOQAaXzUAAGU5AAFlOQAAZTkAAGU5AABlOQAAZTkAyWU5AP5lOQD8ZTkA/2U5AP5lOQD+ZTkA8mM3ABtlOQAAZTkAAAAAAAAAAAAAAAAAAP///wD///8AAAAAAAAAAAAAAAAAZTkAAmU5AABmOQA4ZTkA/mU5APxlOQD/ZTkA/2U5AP9lOQD+ZTkA/2U5APtlOQD7ZTkA/GU4APtlOQD/ZDkA/2U4AP9kOQHyZDkC1GQ5Ar5kOQK+ZDkC2mQ5Av9lOQD7XDQBe2U5AABlOQAAZTkAAGU5AAJlOQAAZTkAnGU5AP9lOQD6ZTkA/2U5AP9lOQD7ZTkA/2U5AE5kOAAAZTkAAwAAAAAAAAAAAAAAAP///wD///8AAAAAAAAAAAAAAAAAZTkABGU5AABkOABwZTkA/mU5APllOQD+ZTkA/2U5AP9lOQD/ZTkA/mU5AP9lOQD9ZTgA/WM5Af9mNwDtaDYAk2c3ADhqNwADbTgAAP8AAACYLQAAbDgAAGg3AAJoNwA+aTkApmc3AJ5mOAAZZDkBAGQ5AQRlOQAAZTkAbGU5AP5lOQD6ZTkA/mU5AP5lOQD5ZTkA/mU5AIhmOQAAZTkABGU5AAAAAAAAAAAAAP///wD///8AAAAAAAAAAABlOQAAZTkAAmU5AABlOQCrZTkA/mU5APplOQD/ZTkA/2U5AP9lOQD+ZTkA/2U5AP1kOQD/ZTgA/m01AIxiPCIIPVFpACdSozgOZOaEDmPnuBJf3M8SX93QDWPqvQ9j5I0nWaVEOUZwAGE7LxteOxBKbDUACmk2AAJkOQEAZTkAP2U5AP9lOQD9ZTkA/2U5AP9lOQD7ZTkA/mU5AMFdNAAAZTkAAWU5AAAAAAAAAAAAAP///wD///8AAAAAAAAAAABlOQAAZTkAAGU5AAZlOQDeZTkA/2U5APxlOQD/ZTkA/2U5AP5lOQD/ZTkA/GQ5Af9nNwDnYjoJRD9LcgARZONVDWPo0g5h5/8SXtv/E17a/xNe2/8TXtv/E17Z/xNe2/8OYOb/Dl7k4BNg4GgWXdAAG1rEAEZHUwJoNwAAZTgAGWU5APNlOQD/ZTkA/mU5AP9lOQD9ZTkA/2U5AO5fNQARZTkAAGU5AAAAAAAAAAAAAP///wD///8AAAAAAAAAAABlOQABZTkAAGU5ACtlOQD8ZTkA/WU5AP5lOQD/ZTkA/2U5AP9lOQD8ZTgA/mg2AORWPyQoK06ZAg1j5qsSXtr/E17Z/xNe2fwTX9z3E17b9hJf3PgSX9z4E17b9hNf3PcTXtn7E1/b/xJe2/8RX97CEWDfHA9g5ABaPB4CYjoAAWU5ANNlOQD+ZTkA/GU5AP9lOQD/ZTkA/GU5AP9mOQBAZTkAAGU5AAIAAAAAAAAAAP///wD///8AAAAAAAAAAABlOQADZTkAAGU5AGJlOQD/ZTkA+mU5AP9lOQD/ZTkA/mU5AP1lOQD7YjkC9lNAMTMxUY8DEGHgxhRd2P8SXtz6E1/c/BNe2/wTXtv/E17b/xNe2/8TXtv/E1za/xNc2/8TXtv9E17c/BNf3PkTXtv/El/c3hNf2SEzXJ4AcDMAAGU4AKllOQD/ZTkA+mU5AP9lOQD+ZTkA+mU5AP5lOQB6ZTkAAGU5AANlOQAAAAAAAP///wD///8AAAAAAGU5AABlOQACZTkAAGU5AJ5lOQD+ZTkA+mU5AP5lOQD/ZTkA/2U5APxlOAD/azMAbkdObwAPZ+SuEl7b/xJe2/kSX9z+El7b/xJf2/8SYd3QEWPehxJg3F4OeeZZD3jmfQ915cIRZ+D/El3b/xNc2v0SYNz6E17b/xFf3NETbNoNaDcbAWQ5AHplOQD+ZTkA+WU5AP5lOQD/ZTkA+2U5AP5lOQC2ZTkAAGU5AAFlOQAAAAAAAP///wD///8AAAAAAGU5AABlOQAAWjIAAWU5ANNlOQD/ZTkA/GU5AP9lOQD+ZTkA/GU5AP5hPQfXPmaAABWZ6VcRaN//E1za+BJf3P0SXtv/El/c8xFk3mURZN4FEmDcABFl3gAA4/8AB6r/AAa0/wAIo/hNDIfw4RFl3/8TWdn9El/c+RJe2/8XXM6KPkpjAF05ClFlOQD/ZTkA+mU5AP9lOQD/ZTkA/WU5AP9lOQDmZTkACGU5AABlOQAAAAAAAP///wD///8AAAAAAGU5AAFlOQAAYzgAH2U5APllOQD+ZTkA/mU5AP9lOQD/ZTkA+mU4AP9sKABmWlZbAAqR89sSYNz9El7b+xNe2/wSXtv0EmLdPBJg3AATXtsBEmHcAxFh3AMDy/8DBrH/Awmh/gIIp/4ABbr/IAih/OIPceX9E1nZ/BJf2/0SXtv1IV66FH8zAB1kOQD8ZTkA/WU5AP5lOQD/ZTkA/2U5AP1lOQD+ZTkAM2U5AABlOQACAAAAAP///wD///8AAAAAAGU5AANlOQAAZTkAVGU5AP9lOQD6ZTkA/2U5AP9lOQD+ZTkA/mM5AvdrW1QPBsf/OwuQ9P8TWtn9EV/c/BJe2/8RYt1vEl7bABNe2wYSX9wAE1/cABJi3QAAAAAACaD9AAmk/wAJo/8FCKj+AAij+0MIpf7+EG7j/BJb2fsSX9z/DGLqbyBx1gBjOQPjZTkA/2U5AP1lOQD/ZTkA/mU5APllOQD+ZTkAbGU5AABlOQAEAAAAAP///wD///8AZTkAAGU5AARlOQAAZTkAj2U5AP5lOQD5ZTkA/mU5AP9lOQD8ZTkA/2I6BNATr9wAB6b9iAqS9f4TWtn5EV/c/hJf3OUTWtkIEl/cAhNf3AATX9wAAAAAAAAAAAAAAAAAAAAAAAmk/wAJof8ACaL/Awir+wAIpf7DCZ37/xFi3fgSXdr+FV7UtzFMegBjOQK7ZTkA/mU5APtlOQD/ZTkA/2U5APplOQD+ZTkAp2U5AABlOQADZTkAAP///wD///8AZTkAAGU5AAFlOQAAZTkAx2U5AP9lOQD7ZTkA/2U5AP9lOQD6ZTkA/mM6BKQ6aHQACqP5swmZ+f4SXdv2El7b/xJf26oTWtkAE13bAxNf3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACKT/BQmj/wAJof18B6j//g2E7vcTWdn/FF/X3XAuBwBlOACJZTkA/mU5APplOQD+ZTkA/2U5APxlOQD/ZTkA22U5AARlOQAAZTkAAP///wD///8AZTkAAGU5AABlOQAUZTkA8mU5AP5lOQD+ZTkA/2U5AP5lOQD6ZTkA/mM6A3RCYFwAC6D4wgij/v8RaOD3E1za/hJg3JESX9wAEl/cBRNf3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACaT/BAik/wAJov5iCKT+/wme+/gRYt3/FF3X5s4KAABnNwBZZTkA/2U5APtlOQD/ZTkA/2U5AP5lOQD9ZTkA+2U5ACZlOQAAZTkAAf///wD///8AZTkAAmU5AABlOQBFZTkA/2U5APtlOQD/ZTkA/2U5AP9lOQD8ZTkA/2I7CEc2bX4ACp/5uQeo//8Nge32E1nZ/hFg3J4TXdsAE17bBBNf3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJpP8ACaT/BQmk/wAJpP9wCaL9/gen//gPceT/FFrX38cAAABpNgAuZTkA/WU5AP1lOQD+ZTkA/2U5AP9lOQD6ZTkA/2U5AFxlOQAAZTkAA////wD///8AZTkAA2U5AABlOQCAZTkA/mU5APllOQD+ZTkA/2U5AP5lOQD+ZTkA9VNKIyEghr4ACaL8lQik/v4IoPz4EWXf/xJd2tYUUtIBEl/cARNg3QATX9wAAAAAAAAAAAAAAAAAAAAAAAmk/wAJpP8ACKP9Awmk/wAJo/6sCKH+/wip/vcOe+r+E1jYwSwyhQBRQSkQZTkA6GU5AP9lOQD9ZTkA/2U5AP5lOQD5ZTkA/mU5AJhlOQAAZTkAA////wD///8AZTkAAWU5AABlOQC5ZTkA/mU5APplOQD/ZTkA/2U5APxlOQD/ZTkA12hBPgYDsf8ACKT/Vwmi/v8Hp//8C5L1/BJb2v8RY91JElvZABJf3AMTXtsAE1/cAAAAAAAAAAAACaT/AAmk/wAJpP8CCaX/AAmk/x8JpP/0CKH+/Qip/voNfuz/ElbZhwNN/QCaJCQAZTkAxGU5AP5lOQD7ZTkA/2U5AP9lOQD7ZTkA/2U5AM5aMwAAZTkAAP///wD///8AZTkAAGU5AA5lOQDoZTkA/2U5AP1lOQD/ZTkA/2U5APplOQD+ZTkArnEuAABRcnkBCaT/EAik/+sJov79B6j/+wuM8v0SXNrdFFPVFRNc2gASYt0FFFnVAwD//wEJpP8BCaT/Agmk/wUJpP8ACJTmAQmk/7sJpP//CaL9/Aeo//wNfev9G0TFMBdN0AB0MQAAZTkAmGU5AP5lOQD6ZTkA/2U5AP9lOQD+ZTkA/mU5APZjOAAdZTkAAP///wD///8AZTkAAGU5ADplOQD+ZTkA/GU5AP9lOQD/ZTkA/mU5APllOQD+ZTkAgGI7AAA7ZnMHCaT/AAmj/oAJpP7/CaL++Qeo//0Klvf/D2/jzhRN0ysVTdMAFVTTAAPT/wAIpf4ACaT/AAmk/wAJpP8VCKH6rQmk//8Jo/78CKP++gii/f8OeumvFYveAD9ycQZiOgAAZTkAaGU5AP5lOQD5ZTkA/mU5AP9lOQD/ZTkA+2U5AP9lOQBQZDgAAP///wD///8AZTkAAGU5AHJlOQD+ZTkA+mU5AP5lOQD/ZTkA/2U5APplOQD/ZTkAUmU4AABePxADCaT/Agmk/wsJo//WCaT//wmi/vsIpv/8CKL9/wuS9fQOeemTEHTiQwuP7B0IpP4aCaT/Ngmk/30JpP/jCaT//wmk//sJo/78CKT//Qmh/e8LjfMhCZP5AU9HNwRlOAAAZTkAPGU5AP9lOQD8ZTkA/2U5AP9lOQD+ZTkA+mU5AP5lOQCLZjkAAP///wD///8AZTkAAGU5AK5lOQD+ZTkA+2U5AP9lOQD/ZTkA/mU5AP1lOQD8ZTkAKGU5AABmNwABCaT/Agmk/wAJpP8qCaP+6gik//8Jo/75CKT//Qil//8Ipv//CKb//wil/vcIpP71CaT//wmk//8JpP//CaT//Amk//oJpP//CaP++Qik/0cIpf8ACKf/AnAxAABlOQAAZTkAFmU5APNlOQD/ZTkA/mU5AP9lOQD/ZTkA+2U5AP9lOQDFXDQAAP///wD///8AZTkABmU5AOBlOQD/ZTkA/WU5AP9lOQD/ZTkA/WU5AP9lOQDlZTkACWU5AABXSCQACaT/AAmk/wIJpP8ACaT/MQmj/twIpP7/CKP+/wmj//oJo/74CaP++wmj/v8JpP//CaT//Amk//gJpP/6CaT//Qmk//8Jo/7uCKT/Swmk/wAJpP8DCaT/AHMsAABlOQAAZTkAAWU5ANNlOQD+ZTkA/GU5AP9lOQD/ZTkA/mU5AP5lOQDwYDYAE////wD///8AZTkAL2U5AP1lOQD9ZTkA/2U5AP9lOQD+ZTkA+2U5AP5lOQC/ZTkAAGU5AAJlOQAACaT/AAmk/wAJpP8CCaT/AAmk/xQJpP+aCaT/+Qmk//8JpP//CaT//wmk//8JpP//CaT//wmk//8JpP//CaT//wmk/68JpP8kCaT/AAmk/wMJpP8ACaT/AGU5AABlOQADZTkAAGQ4AKllOQD+ZTkA+mU5AP5lOQD/ZTkA/2U5APtlOQD/ZTkARf///wD///8AZTkAaWU5AP5lOQD5ZTkA/mU5AP5lOQD/ZTkA+WU5AP1lOQCQZTkAAGU5AAQAAAAAAAAAAAmk/wAJpP8ACaT/Agmk/wAJpP8ACaT/Kgmk/4IJpP/FCaT/6Qmk//gJpP/6CaT/7Qmk/80JpP+PCaT/OAmk/wAJpP8ACaT/Awmk/wAJpP8AAAAAAAAAAABlOQAEZTkAAGY5AHdlOQD+ZTkA+WU5AP9lOQD+ZTkA/mU5APllOQD+ZTkAgv///wD///8AZTkAomU5APxlOQD4ZTkA/GU5APxlOQD7ZTkA+WU5AP9lOQA7ZTkAAGU5AAIAAAAAAAAAAAAAAAAJpP8ACaT/AAmk/wEJpP8DCaT/AAmk/wAJpP8ACaT/EAmk/yEJpP8jCaT/FAmk/wAJpP8ACaT/AAmk/wIJpP8BCaT/AAmk/wAAAAAAAAAAAAAAAABlOQABZTkAAF41ACdlOQD9ZTkA+2U5APtlOQD8ZTkA/GU5APhlOQD8ZTkAuv///wD///8AZTkA32U5AP9lOQD/ZTkA/2U5AP9lOQD/ZTkA/2U5AJllOQAAZTkAAWU5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmk/wAJpP8ACaT/AQmk/wMJpP8ACaT/AAmk/wAJpP8ACaT/AAmk/wAJpP8DCaT/Agmk/wAJpP8AAAAAAAAAAAAAAAAAAAAAAAAAAABlOQAAZTkAAV41AABlOQCCZTkA/2U5AP9lOQD/ZTkA/2U5AP9lOQD/ZTkA8f///wD///8AZTkAwGU5ANJlOQDRZTkA0WU5AM5lOQC4ZTkAZmU5AABlOQABZTkAAGU5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmk/wAJpP8AAAAAAAmk/wEJpP8BAAAAAQAAAAAJpP8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlOQAAZTkAAGc6AAFlOQAAZTkAWmU5ALNlOQDNZTkA0GU5ANBlOQDRZTkAyv///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///////8AAP///////wAA////////AAD///////8AAP///////wAA/+D//wf/AAD/wP//A/8AAP+A//8B/wAA/4D//wH/AAD/gf//gP8AAP8B//+A/wAA/wH//4D/AAD/Af//gP8AAP8B//+AfwAA/gP//8B/AAD+AAB/wH8AAP4AAB/AfwAA/gAAB8B/AAD8AA/zwD8AAPwAOB/gPwAA/ADAA+A/AAD8AYAB4D8AAPgDAADgHwAA+AIAAGAfAAD4BAfwIB8AAPgEH/gwHwAA8Awf/BAPAADwCD/8EA8AAPAIP/wQDwAA8Ag//BAPAADwGD/8GAcAAOAYP/wYBwAA4Bg//BgHAADgHB/4OAcAAOAcD/A4AwAAwB4DwHwDAADAPwAA/AMAAMA/gAH8AwAAwD/AA/wDAACAP/AP/AEAAIB////+AQAAgH////4BAACA/////wEAAP///////wAA////////AAD///////8AAP///////wAA////////AAAoAAAAIAAAAEAAAAABACAAAAAAAIAQAAAAAAAAAAAAAAAAAAAAAAAA////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AABlOQBFZTkA82U5AP9lOQD/ZTkAn2U5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGU5AABlOQCNZTkA/2U5AP9lOQD5ZTkAU2U5AAD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8AXjUAAGU5ANtlOQD/ZTkA/2U5AP9lOQBfZTkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZTkAAGU5AFBlOQD/ZTkA/2U5AP9lOQDpZTkAA////wD///8A////AP///wD///8A////AP///wD///8A////AP///wBkOAAeZTkA/2U5AP9lOQD/ZTkA/2U5ADBlOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABlOQAAZTkAI2U5AP9lOQD/ZTkA/2U5AP9lOQAs////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AFZlOQD/ZTkA/2U5AP9lOQDxXzYAC2U5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGU5AABeNQAEZTkA52U5AP9lOQD/ZTkA/2U5AGf///8A////AP///wD///8A////AP///wD///8A////AP///wD///8AZTkAlWU5AP9lOQD/ZTkA/2U5AMthNgAAZTkAAGU5AABlOQAAZTkAAGU5AABlOQAAZTkAAAAAAAAAAAAAZTkAAGM4AABlOQC+ZTkA/2U5AP9lOQD/ZTkApf///wD///8A////AP///wD///8A////AAAAAAAAAAAAZTkAAGA2AABlOQDPZTkA/2U5AP9lOQD/ZTkAjmU5AABlOQADZTkAFGU5ABVlOQAHZTkAAGU5AABlOQAAZTkAAGU5AABlOQAAZTkAAGU5AJBlOQD/ZTkA/2U5AP9lOQDdZTkAAGU5AAAAAAAAAAAAAP///wAAAAAAAAAAAAAAAABlOQAAYTcAE2U5APllOQD/ZTkA/2U5AP9lOQDBZTkAr2U5AOJlOQD1ZTkA+WU5APBlOQDOZTkAhWU5ACRlOQAAZTkAAGU5AABlOQAAZTkAXmU5AP9lOQD/ZTkA/2U5AP5lOQAfZTkAAAAAAAAAAAAAAAAAAP///wAAAAAAZTkAAGU5AABlOQBGZTkA/2U5AP9lOQD/ZTkA/2U5AP9lOQD/ZTkA/2U4AP9mOAD/ZzgA92g3AOJpNwDmZzcA42Y4AJJlOAAVZTkAAGU5AABlOQAxZTkA/2U5AP9lOQD/ZTkA/2U5AFZlOQAAZTkAAAAAAAAAAAAA////AAAAAABlOQAAZTkAAGU5AINlOQD/ZTkA/2U5AP9lOQD/ZTkA/2Q5AP9mNwD/ZTgAmFw9FzpRPzMnO01tLzxMbDBXPyMzXjwRWGU5CmhoNwAcZzcAAGU5AAxlOQDxZTkA/2U5AP9lOQD/ZTkAlGU5AABlOQAAAAAAAAAAAAD///8AAAAAAGU5AABiNwAAZTkAv2U5AP9lOQD/ZTkA/2U5AP9kOQD/aDYA2lFOSSoqV5k0FF7VpA5g6OcPYOX/D2Dk/w1h6usVXtOuIli+UyxTmApWPycAZzgAAGU5AMxlOQD/ZTkA/2U5AP9lOQDNZTkAAGU5AAAAAAAAAAAAAP///wAAAAAAZTkAAF81AAplOQDvZTkA/2U5AP9lOQD/ZDkA/2o1ANZSTWoFHV/PfA9g5P8SX93/El/c/xJf3P8TXdv/E13b/xJe3P8QX9//D2HjoxVd1ANWPiAAZDkAn2U5AP9lOQD/ZTkA/2U5APdlOQAVZTkAAAAAAAAAAAAA////AAAAAABlOQAAZTkAOmU5AP9lOQD/ZTkA/2U5AP9kOAD6fTY4ExBp6H8PX+H/E17b/xBf3f8SYNzVE1rYmhBr4pYRbN/MEmLe/xNc2v8TXdv/EGDgsU5HYgBlOABpZTkA/2U5AP9lOQD/ZTkA/2U5AEplOQAAZTkAAAAAAAD///8AZTkAAGU5AABlOQB3ZTkA/2U5AP9lOQD/ZDkA/3MqAH8KufQkDmfj/xNc2v8SXtv+HV3SZxJf3AAUWdYABbf/AAuZ9AAJnvRUDn3r9hJe2/8SXdr/E2XpTZEjACdkOQD/ZTkA/2U5AP9lOQD/ZTkAiGU5AABlOQAAAAAAAP///wBlOQAAYzgAAGU5ALVlOQD/ZTkA/2U5AP9lOAD9iCcAGACh/6kRYt3/E1za/w9i33AaW9QAEmLdABRW1AAMivIAAOT/AAmf/AAFuf9SDInx/xNa2f8JYe3Mei8hDmU3APRlOQD/ZTkA/2U5AP9lOQDEYTcAAGU5AAAAAAAA////AGU5AABeNQAFZTkA6GU5AP9lOQD/ZTkA/2c0ANwhwLcMB5z/6xJg3P8SXNroIFK/ABBg3gASYNwAAAAAAAAAAAAJpP8ACKb/AAin/AAGrf/SDnrp/xFZ3P0IZ+gcaTYAy2U5AP9lOQD/ZTkA/2U5APJgNgANZTkAAAAAAAD///8AZTkAAGU5AC5lOQD/ZTkA/2U5AP9lOQD/ajEArwD//w0IpP/+EWbf/xNa2cATW9cAE1/cAAAAAAAAAAAAAAAAAAAAAAAJpP8ACaP/AAep/6EJm/r/El7c/wBs/yVsNACdZTkA/2U5AP9lOQD/ZTkA/2U5AD1lOQAAZTkAAP///wBlOQAAZTkAaGU5AP9lOQD/ZTkA/2U5AP9rMACCoFJPAgep//oNgOz/E1XW0yBVzgASX9sAE1/cAAAAAAAAAAAAAAAAAAmk/wAJpP8ACKX/tQil//8QauH/AFr/F24zAG5lOQD/ZTkA/2U5AP9lOQD/ZTkAemU5AABlOQAA////AGU5AABlOQCnZTkA/2U5AP9lOQD/ZTkA/2c0AFdvNygACKX/2Qij/f8QaOD9GUrOLhJg3AANg+kAE1/cAAmk/wAJpP8ACaT/AAmk/xMIo//0CKX//w9z5vF1fUYAbDQARGU5AP9lOQD/ZTkA/2U5AP9lOQC3ZTkAAGU5AAD///8AZTkAAGU5AN5lOQD/ZTkA/2U5AP9lOQD/ZTkALiR+ngAJpP97CKf//wmb+f8PbePSFF7UERJj3AAA3f8ACaL+AAmk/wAJpP8ECaT/ugek//8IoP3/D3TmnDFziwBlOAAhZTkA/mU5AP9lOQD/ZTkA/2U5AOplOQAGZTkAAP///wBlOQAiZTkA/mU5AP9lOQD/ZTkA/2U5APFgNgAKR1pQAAiZ7goJo//iCKb//wii/f8Mi/LhDYXraQ2B6ykJo/4lCaT/Wwmk/9EJpP//CKT//wmg/fMMivEZO2BxAGQ5AANlOQDmZTkA/2U5AP9lOQD/ZTkA/2U5ADBlOQAA////AGU5AFtlOQD/ZTkA/2U5AP9lOQD/ZTkAzGE2AABmNwAACKP9AAmk/ysJo//qCKT//wil//8IpP//CKT+/wmj/v8JpP//CaT//wmk//8Jo//2CaT/Pwil/wBlOAAAZTkAAGU5AL5lOQD/ZTkA/2U5AP9lOQD/ZTkAa2U5AAD///8AZTkAmmU5AP9lOQD/ZTkA/2U5AP9lOQCgZTkAAGU4AAAAAAAACaT/AAmk/x0JpP+wCaP//wmk//8Jo///CKT//wmk//8JpP//CaT/vQiY7SoJpP8ACaT/AEpXSABlOQAAZTkAkGU5AP9lOQD/ZTkA/2U5AP9lOQCqZTkAAP///wBlOQDPZTkA/2U5AP9lOQD/ZTkA/2U5AGFlOQAAZTkAAAmk/wAJpP8ACaT/AAmk/wAJpP8tCaT/cwmk/5oJpP+cCaT/eAmk/zUJpP8ACaT/AAmk/wAJpP8AZTkAAGU5AABkOABQZTkA/2U5AP9lOQD/ZTkA/2U5ANxlOQAAYjcARGU5AP9lOQD/ZTkA/2U5AP9lOQDKZTkACGU5AAAAAAAAAAAAAAAAAAAJpP8ACaT/AAmk/wAJpP8ACaT/AAmk/wAJpP8ACaT/AAmk/wAJpP8AAAAAAAAAAAAAAAAAZTkAAF41AANiNwC+ZTkA/2U5AP9lOQD/ZTkA/2U5AFT///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP/////////////////////+H/g//B/4P/w//D/4P/wf+D/8H/g//B/4AHwf+AAeD/AHzg/wGA4P8CAGD/BAAg/gQ8MH4IfhB+CP8Qfgj/EHwI/xA8CP8YPBh+GDwcGDg4HgB4GB8A+Bgfw/gYP//8D/////////////////////KAAAABgAAAAwAAAAAQAgAAAAAABgCQAAAAAAAAAAAAAAAAAAAAAAAP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wBlOQALZTkAyWU5AP9lOQD4ZTkACWU5AAAAAAAAAAAAAAAAAAAAAAAAZTkAAF81AARlOQDwZTkA/2U5ANJlOQAQ////AP///wD///8A////AP///wD///8A////AP///wBlOQBhZTkA/2U5AP9lOQDKZTkAAGU5AAAAAAAAAAAAAAAAAAAAAAAAZTkAAGU5AABlOQDAZTkA/2U5AP9lOQBu////AP///wD///8A////AP///wD///8A////AP///wBlOQCjZTkA/2U5AP9lOQCWZTkAAGU5AAAAAAAAAAAAAAAAAAAAAAAAZTkAAGU5AABlOQCKZTkA/2U5AP9lOQCv////AP///wD///8A////AP///wD///8A////AP///wBlOQDcZTkA/2U5AP9lOQBUZTkAAGU5AABlOQAAZTkAAGU5AABcNAAAZTkAAGU5AABlOQBXZTkA/2U5AP9lOQDl////AP///wD///8A////AAAAAAAAAAAAZTkAAGM4ABplOQD+ZTkA/2U5AP1lOQBVZTkAVmU5AHllOQB4ZTkAVWU5ABldNAAAZTkAAGU5AABlOQAqZTkA/2U5AP9lOQD/ZTkAJGU5AAAAAAAAAAAAAAAAAABlOQAAZTkAAGU5AFNlOQD/ZTkA/2U5AP5lOQD/ZDkA/2Y4AP9mNwD/ajYA6Go2AMhkNQCGaDcAHmc3AABlOQAGZTkA72U5AP9lOQD/ZTkAX2U5AABlOQAAAAAAAAAAAABlOQAAZTkAAGU5AJNlOQD/ZTkA/2U5AP9kOQD/ajYA5F4+IGpKPjtOO01vXj1LaGhLR0VxVUExUVw+GgZnNwAAZDkAyGU5AP9lOQD/ZTkAn2U5AABlOQAAAAAAAAAAAABlOQAAZTkAAGU5AM9lOQD/ZTkA/2Q5AP9vMwC/N2CeJhdf2poOYOj8DWHp/w1h6/8QX+L/EWDguBRg1y5VPywAZDkAm2U5AP9lOQD/ZTkA2mA2AABlOQAAAAAAAAAAAABlOQAAZTkAEmU5APplOQD/ZDkA/2o1AOA5U4ceCWPv1RBf3/8SX939El7buhJm3LYSZd33E13a/xJc2vQqXbIYdTAAVmQ5AP9lOQD/ZTkA/mQ4ABtlOQAAAAAAAAAAAABlOQAAZTkARmU5AP9lOQD/ZTgA/287AlgAgv+YEl3a/xJf3NASYNweEl7bAAuW9QARiuIVCpH1wRFj3v8CY/+7cjINK2U4AP9lOQD/ZTkA/2U5AFJlOQAAZTkAAGU5AABlOQAAZTkAhGU5AP9lOQD/aTIA8zKIjDYJgPb8E1nZ/BJc2yESX9sAE1zaAA965gAIo/8ACrXoDwuR9fQQXeL/KlGWRGo1AOhlOQD/ZTkA/2U5AJFlOQAAZTkAAGU5AABlOQAAZTkAw2U5AP9lOQD/bS4AygDG/z8LifP/E1jY2hFm3gASX9wAAAAAAAAAAAAIpP8ADJHxAAer/8IOdun/C1HqUm00AL9lOQD/ZTkA/2U5AM5hNwAAZTkAAGU5AABlOQAJZTkA82U5AP9lOQD/bS0AoxDm+CEJnfv/EmHc6hRXzgATWtoAE1/cAAmk/wAJpP8ACKj/AAeq/9gMh/D/AEz/NW8zAJRlOQD/ZTkA/2U5APlhNwAQZTkAAGU5AABlOQA5ZTkA/2U5AP9lOQD/aDMAfXlIPQAHqP/wC5D0/xVH0HERbN0AGDbJAAin/wAJpP8ACaT/WAim//8LjfT9YntpA2s1AG1lOQD/ZTkA/2U5AP9lOQBFZTkAAGU5AABlOQB3ZTkA/2U5AP9lOQD/ZDgAUjNrdgAIo/9pCKX//wma+v8OheiODIjtMwmh/S8JpP+ACaT//wij/v8Jl/aBO3RzAGU4AEZlOQD/ZTkA/2U5AP9lOQCEZTkAAGQ4AABlOQC0ZTkA/2U5AP9lOQD/ZTkAJV5AEQAJpP8ACaT/jAik//8Ipf//CKb//wmj/v8JpP//CaT//wmj/psInfQAWUIdAGQ5ABxlOQD/ZTkA/2U5AP9lOQDAZDgAAF82AAhlOQDlZTkA/2U5AP9lOQD1YDYABGY3AAAJpP8ACaT/AAmj/0EJpP+oCaT/2gik/9wJpP+uCaT/Sgmk/wAJq/8AZjcAAF82AABlOQDrZTkA/2U5AP9lOQDuYDYADmU5AGplOQD/ZTkA/2U5AP9lOQB3ZDgAAGU5AAAJpP8ACaT/AAmk/wAJpP8ACaT/AAmk/wAJpP8ACaT/AAmk/wAJpP8AZTkAAGU5AABlOQBrZTkA/2U5AP9lOQD/ZTkAd////wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////APj/HwDw/w8A8P8PAPD/DwDwD48A4AOHAOAhhwDggYcA4QCHAOA8QwDCfkMAwn4DAMJ+QwDCPEMAghhhAIcA4QCHw+EAB//gAP///wD///8A////ACgAAAAQAAAAIAAAAAEAIAAAAAAAQAQAAAAAAAAAAAAAAAAAAAAAAAD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AGU5AHVlOQDsZTkAVGU5AAAAAAAAAAAAAGU5AABlOQBNZTkA7GU5AH3///8A////AP///wD///8A////AP///wBlOQDvZTkA/2U5AC1lOQAAAAAAAGU5AABlOQAAZTkAKWU5AP9lOQD2////AP///wD///8A////AP///wD///8AZTkA/2U5AOtlOQAAZTkAAkMmAABlOQAAZTkAAGU5AAVlOQDtZTkA/////wD///8A////AGU5AABlOQAAZTkAYGU5AP9lOQDuZTkA02U5AOVqNQC0bDUAbmU5ABVlOAAAZDkAwmU5AP9lOQBoZTkAAGU5AABlOQAAZTkAAGU5AJ9kOQD/ZTgA/2U4BdI4VnyFPUlwrjVQfbxCT2pyUkA1AGU4AI5kOQD/ZTkAp2U5AABlOQAAZTkAAGI3AABlOQDYZTgA/2k2AcMbXMZzDGHr+A1h6+MTXd3gEmDc/xVk4m1wMwNNZTgA/2U5AN5eNQAAZTkAAGU5AABkOAAcZTkA/Wg0AP1CXl5xC2nw+xNY2IUSXdsAEYPoAAKq/3YGbvj/PkVlamk2APplOQD/ZTkAI2U5AABlOQAAZTkAVGU5AP9tLgDhGI7TiQxv7P4gGKoAE13bAAeo/wBBeIUACI769BtawpptMwDcZTkA/2U5AFxlOQAAZTkAAGU5AJNlOQD/bS0AwQDD/1gLiPP/Hh6yFxJj3QAJo/4AH5rHCgib/P8BeP9nbjAAumU5AP9lOQCcZTkAAGE2AABlOQDLZTkA/2g0AKVIfYUCCKL96QuQ9eELlu9HCpz2QwOt/9UJoPzxPHWXB2k0AJxlOQD/ZTkA0mI3AABhNgAtZTkA92U5AP9kOQB+TVI8AAik/yUIo/7OCKb//wik/v8JpP/VCaT/LU5SPQBkOQB2ZTkA/2U5APtjOAAzZTkAimU5APJlOQDgZTkAJ2kzAAAJpP8ACaT/AAmk/yAJpP8hCaT/AAmk/wBpMwAAZTkAImU5AN5lOQDzZTkAkf///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A//8AAP//AADj5wAA5+cAAOfnAADAYwAAwCMAAMATAADBgwAAg8EAAIPBAACJkQAAjDEAAB/4AAD//wAA//8AAA=="/>
+</head>
+<body data-spy="scroll" data-target=".scrollspy">
+<div id="sidebar-wrapper" class="hidden-xs">
+    <div class="scrollspy">
+    <h4 class="text-center"><span class="main-title label label-primary text-uppercase">Cats API</span></h4>
+    <ul id="main-menu" data-spy="affix" class="nav">
+        <li>
+            <a href="#doc-general-notes"><span class="glyphicon glyphicon-home"></span> Start</a>
+        </li>
+        
+        <li>
+            <a href="#doc-api-structures">API structures</a>
+            <ul>
+                
+                <li>
+                    <a href="#struct-Dog">Dog</a>
+                </li>
+                
+                <li>
+                    <a href="#struct-Cat">Cat</a>
+                </li>
+                
+            </ul>
+        </li>
+        
+        <li>
+            <a href="#doc-api-detail">API detail</a>
+        </li>
+        
+        <li>
+             <a href="#folder-cats"><span class="icon glyphicon glyphicon-collapse-down"></span><span class="glyphicon glyphicon-collapse-up"></span> Cats</a>
+            <ul>
+                
+
+                
+                <li>
+                    <a href="#request-create-a-new-cat"><small class="strong POST">POST</small> Create a new cat</a>
+                </li>
+                
+
+                
+
+                
+                <li>
+                    <a href="#request-get-all-cats"><small class="strong GET">GET</small> Get all cats</a>
+                </li>
+                
+
+                
+
+                
+                <li>
+                    <a href="#request-get-one-cat"><small class="strong GET">GET</small> Get one cat</a>
+                </li>
+                
+
+                
+
+                
+                <li>
+                    <a href="#request-delete-one-cat"><small class="strong DELETE">DELETE</small> Delete one cat</a>
+                </li>
+                
+
+                
+
+                
+                <li>
+                    <a href="#request-get-zero-cats"><small class="strong GET">GET</small> Get zero cats</a>
+                </li>
+                
+
+                
+            </ul>
+        </li>
+        
+        <li>
+             <a href="#folder-dogs"><span class="icon glyphicon glyphicon-collapse-down"></span><span class="glyphicon glyphicon-collapse-up"></span> Dogs</a>
+            <ul>
+                
+
+                
+                <li>
+                    <a href="#request-get-one-dog"><small class="strong GET">GET</small> Get one dog</a>
+                </li>
+                
+
+                
+            </ul>
+        </li>
+        
+    </ul>
+</div>
+
+</div>
+<div id="page-content-wrapper" class="splitted">
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="row ">
+                    <div class="col-md-7">
+                        <h1 id="doc-general-notes">
+                            Cats API
+                            <a href="#doc-general-notes"><i class="glyphicon glyphicon-link"></i></a>
+                        </h1>
+                    </div>
+                    <div class="col-md-5">
+                        <div class="dropdown">
+                          <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                            Code language
+                            <span class="caret"></span>
+                          </button>
+                          <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+                            <li><a href="#" onClick="$('.request-example-curl').each(function(){$(this).addClass('active')});$('.request-example-http').each(function(){$(this).removeClass('active')});">cURL</a></li>
+                            <li><a href="#" onClick="$('.request-example-curl').each(function(){$(this).removeClass('active')});$('.request-example-http').each(function(){$(this).addClass('active')});">HTTP</a></li>
+                          </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-md-7 doc no-padding">
+                <p>Tu autem, Fanni, quod mihi tantum tribui dicis quantum ego nec adgnosco nec postulo, facis amice; sed, ut mihi videris, non recte iudicas de Catone; aut enim nemo, quod quidem magis credo, aut si quisquam, ille sapiens fuit. Quo modo, ut alia omittam, mortem filii tulit! memineram Paulum, videram Galum, sed hi in pueris, Cato in perfecto et spectato viro.</p>
+
+<p>Novitates autem si spem adferunt, ut tamquam in herbis non fallacibus fructus appareat, non sunt illae quidem repudiandae, vetustas tamen suo loco conservanda; maxima est enim vis vetustatis et consuetudinis. Quin in ipso equo, cuius modo feci mentionem, si nulla res impediat, nemo est, quin eo, quo consuevit, libentius utatur quam intractato et novo. Nec vero in hoc quod est animal, sed in iis etiam quae sunt inanima, consuetudo valet, cum locis ipsis delectemur, montuosis etiam et silvestribus, in quibus diutius commorati sumus.</p>
+
+                </div>
+
+                
+                <h2 id="doc-api-structures">
+                    API structures
+                    <a href="#doc-api-structures"><i class="glyphicon glyphicon-link"></i></a>
+                </h2>
+
+                
+
+                    <h3 id="struct-Dog">
+                        Dog
+                        <a href="#struct-Dog"><i class="glyphicon glyphicon-link"></i></a>
+                    </h3>
+
+                    <p>A greater animal</p>
+
+                    <table class="table table-bordered">
+                    
+                        <tr>
+                            <th>id</th>
+                            <td>int</td>
+                            <td>A unique identifier for the dog</td>
+                        </tr>
+                    
+                        <tr>
+                            <th>color</th>
+                            <td>string</td>
+                            <td>The color of the dog</td>
+                        </tr>
+                    
+                        <tr>
+                            <th>name</th>
+                            <td>string</td>
+                            <td>The name of the dog</td>
+                        </tr>
+                    
+                    </table>
+
+                
+
+                    <h3 id="struct-Cat">
+                        Cat
+                        <a href="#struct-Cat"><i class="glyphicon glyphicon-link"></i></a>
+                    </h3>
+
+                    <p>A great animal</p>
+
+                    <table class="table table-bordered">
+                    
+                        <tr>
+                            <th>id</th>
+                            <td>int</td>
+                            <td>A unique identifier for the cat</td>
+                        </tr>
+                    
+                        <tr>
+                            <th>color</th>
+                            <td>string</td>
+                            <td>The color of the cat</td>
+                        </tr>
+                    
+                        <tr>
+                            <th>name</th>
+                            <td>string</td>
+                            <td>The name of the cat</td>
+                        </tr>
+                    
+                    </table>
+
+                
+
+                
+
+                <a href="#doc-api-detail"><hr class="clear" id="doc-api-detail"></a>
+
+                
+                <div class="endpoints-group ">
+                    <h3 id="folder-cats">
+                        Cats
+                        <a href="#folder-cats"><i class="glyphicon glyphicon-link"></i></a>
+                    </h3>
+                    <hr class="clear">
+
+                    <div class="col-md-7 doc no-padding"><p>Accedebant enim eius asperitati, ubi inminuta vel laesa amplitudo imperii dicebatur, et iracundae suspicionum quantitati proximorum cruentae blanditiae exaggerantium incidentia et dolere inpendio simulantium, si principis periclitetur vita, a cuius salute velut filo pendere statum orbis terrarum fictis vocibus exclamabant.</p>
+
+<p>Quod cum ita sit, paucae domus studiorum seriis cultibus antea celebratae nunc ludibriis ignaviae torpentis exundant, vocali sonu, perflabili tinnitu fidium resultantes. denique pro philosopho cantor et in locum oratoris doctor artium ludicrarum accitur et bybliothecis sepulcrorum ritu in perpetuum clausis organa fabricantur hydraulica, et lyrae ad speciem carpentorum ingentes tibiaeque et histrionici gestus instrumenta non levia.</p>
+</div>
+
+                    
+
+                        
+                        <div class="request">
+                            <div class="col-md-7">
+                            <h4 id="request-create-a-new-cat">
+                                <span class="strong POST">POST</span> Create a new cat
+                                <a href="#request-create-a-new-cat"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+                            <input class="bg-warning form-control" disabled value="http://{{domain}}/api/cats" style="width:95%">
+                            <span class="markdown">
+                                <p>Quae dum ita struuntur, indicatum est apud Tyrum indumentum regale textum occulte, incertum quo locante vel cuius usibus apparatum. ideoque rector provinciae tunc pater Apollinaris eiusdem nominis ut conscius ductus est aliique congregati sunt ex diversis civitatibus multi, qui atrocium criminum ponderibus urgebantur.</p>
+
+                            </span>
+                            <hr class="clear">
+
+                            
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    
+                                    <li role="presentation" class="active">
+                                        <a href="#request-create-a-new-cat-responses-70cc5991-fbbf-791f-902b-ecfe4b37df35" data-toggle="tab">
+                                            
+                                                Response
+                                            
+                                        </a>
+                                    </li>
+                                    
+                                </ul>
+                                <div class="tab-content">
+                                    
+                                    <div class="tab-pane active" id="request-create-a-new-cat-responses-70cc5991-fbbf-791f-902b-ecfe4b37df35">
+                                        <table class="table table-bordered">
+                                            <tr><th style="width: 20%;">Status</th><td>201 Created</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Length</th><td>0</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Type</th><td>text/plain; charset=utf-8</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Date</th><td>Tue, 23 Feb 2016 16:36:18 GMT</td></tr>
+                                            
+                                            
+                                        </table>
+                                    </div>
+                                    
+                                </div>
+                            </div>
+                            
+                                
+
+                                
+
+                            
+                            </div>
+
+                            <div class="col-md-5">
+                                <div class="code">
+                                    <small class="PATCH">Sample request</small>
+                                    <div class="panel panel-dark">
+                                        <div class="panel-heading">
+                                            <small>Create a new cat</small>
+                                        </div>
+                                        <div class="panel-body">
+                                            <div class="tab-content">
+                                                <div class="tab-pane active request-example-curl">
+                                                    <pre><code class="hljs curl">curl -X POST -d '{
+    "name": "Doctor Frankeinstein",
+    "color": "brown"
+}' "http://{{domain}}/api/cats"</code></pre>
+                                                </div>
+                                                <div class="tab-pane request-example-http">
+                                                    <pre><code class="hljs http">POST /api/cats HTTP/1.1
+Host: {{domain}}
+
+{
+    "name": "Doctor Frankeinstein",
+    "color": "brown"
+}</code></pre>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                        <hr class="clear">
+                        
+
+                    
+
+                        
+                        <div class="request">
+                            <div class="col-md-7">
+                            <h4 id="request-get-all-cats">
+                                <span class="strong GET">GET</span> Get all cats
+                                <a href="#request-get-all-cats"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+                            <input class="bg-warning form-control" disabled value="http://{{domain}}/api/cats" style="width:95%">
+                            <span class="markdown">
+                                <p>Sed si ille hac tam eximia fortuna propter utilitatem rei publicae frui non properat, ut omnia illa conficiat, quid ego, senator, facere debeo, quem, etiamsi ille aliud vellet, rei publicae consulere oporteret?</p>
+
+                            </span>
+                            <hr class="clear">
+
+                            
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    
+                                    <li role="presentation" class="active">
+                                        <a href="#request-get-all-cats-responses-91ee2389-3d6d-a56a-83a9-dbb713a35e7c" data-toggle="tab">
+                                            
+                                                Response
+                                            
+                                        </a>
+                                    </li>
+                                    
+                                </ul>
+                                <div class="tab-content">
+                                    
+                                    <div class="tab-pane active" id="request-get-all-cats-responses-91ee2389-3d6d-a56a-83a9-dbb713a35e7c">
+                                        <table class="table table-bordered">
+                                            <tr><th style="width: 20%;">Status</th><td>200 OK</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Length</th><td>81</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Type</th><td>application/json</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Date</th><td>Tue, 23 Feb 2016 16:36:33 GMT</td></tr>
+                                            
+                                            
+                                                
+                                                <tr><td class="doc response-text-sample" colspan="2">
+                                                    <pre><code>[
+    {
+        "id": "56cc8a8228a4dbe55ca6e6ec",
+        "name": "Doctor Frankeinstein",
+        "color": "brown"
+    }
+]</code></pre>
+                                                </td></tr>
+                                                
+                                            
+                                        </table>
+                                    </div>
+                                    
+                                </div>
+                            </div>
+                            
+                                
+
+                                
+
+                            
+                            </div>
+
+                            <div class="col-md-5">
+                                <div class="code">
+                                    <small class="PATCH">Sample request</small>
+                                    <div class="panel panel-dark">
+                                        <div class="panel-heading">
+                                            <small>Get all cats</small>
+                                        </div>
+                                        <div class="panel-body">
+                                            <div class="tab-content">
+                                                <div class="tab-pane active request-example-curl">
+                                                    <pre><code class="hljs curl">curl -X GET "http://{{domain}}/api/cats"</code></pre>
+                                                </div>
+                                                <div class="tab-pane request-example-http">
+                                                    <pre><code class="hljs http">GET /api/cats HTTP/1.1
+Host: {{domain}}</code></pre>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                        <hr class="clear">
+                        
+
+                    
+
+                        
+                        <div class="request">
+                            <div class="col-md-7">
+                            <h4 id="request-get-one-cat">
+                                <span class="strong GET">GET</span> Get one cat
+                                <a href="#request-get-one-cat"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+                            <input class="bg-warning form-control" disabled value="http://{{domain}}/api/cats/{{catId}}" style="width:95%">
+                            <span class="markdown">
+                                <p>Ciliciam vero, quae Cydno amni exultat, Tarsus nobilitat, urbs perspicabilis hanc condidisse Perseus memoratur, Iovis filius et Danaes, vel certe ex Aethiopia profectus Sandan quidam nomine vir opulentus et nobilis et Anazarbus auctoris vocabulum referens, et Mopsuestia vatis illius domicilium Mopsi, quem a conmilitio Argonautarum cum aureo vellere direpto redirent, errore abstractum delatumque ad Africae litus mors repentina consumpsit, et ex eo cespite punico tecti manes eius heroici dolorum varietati medentur plerumque sospitales.</p>
+
+                            </span>
+                            <hr class="clear">
+
+                            
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    
+                                    <li role="presentation" class="active">
+                                        <a href="#request-get-one-cat-responses-09bf9394-41e6-ef09-1868-3cd789ebb020" data-toggle="tab">
+                                            
+                                                Response
+                                            
+                                        </a>
+                                    </li>
+                                    
+                                </ul>
+                                <div class="tab-content">
+                                    
+                                    <div class="tab-pane active" id="request-get-one-cat-responses-09bf9394-41e6-ef09-1868-3cd789ebb020">
+                                        <table class="table table-bordered">
+                                            <tr><th style="width: 20%;">Status</th><td>200 OK</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Length</th><td>79</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Content-Type</th><td>application/json</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Date</th><td>Tue, 23 Feb 2016 16:36:44 GMT</td></tr>
+                                            
+                                            
+                                                
+                                                <tr><td class="doc response-text-sample" colspan="2">
+                                                    <pre><code>{
+    "id": "56cc8a8228a4dbe55ca6e6ec",
+    "name": "Doctor Frankeinstein",
+    "color": "brown"
+}</code></pre>
+                                                </td></tr>
+                                                
+                                            
+                                        </table>
+                                    </div>
+                                    
+                                </div>
+                            </div>
+                            
+                                
+
+                                
+
+                            
+                            </div>
+
+                            <div class="col-md-5">
+                                <div class="code">
+                                    <small class="PATCH">Sample request</small>
+                                    <div class="panel panel-dark">
+                                        <div class="panel-heading">
+                                            <small>Get one cat</small>
+                                        </div>
+                                        <div class="panel-body">
+                                            <div class="tab-content">
+                                                <div class="tab-pane active request-example-curl">
+                                                    <pre><code class="hljs curl">curl -X GET "http://{{domain}}/api/cats/{{catId}}"</code></pre>
+                                                </div>
+                                                <div class="tab-pane request-example-http">
+                                                    <pre><code class="hljs http">GET /api/cats/%7B%7BcatId%7D%7D HTTP/1.1
+Host: {{domain}}</code></pre>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                        <hr class="clear">
+                        
+
+                    
+
+                        
+                        <div class="request">
+                            <div class="col-md-7">
+                            <h4 id="request-delete-one-cat">
+                                <span class="strong DELETE">DELETE</span> Delete one cat
+                                <a href="#request-delete-one-cat"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+                            <input class="bg-warning form-control" disabled value="http://{{domain}}/api/cats/{{catId}}" style="width:95%">
+                            <span class="markdown">
+                                <p>Homines enim eruditos et sobrios ut infaustos et inutiles vitant, eo quoque accedente quod et nomenclatores adsueti haec et talia venditare, mercede accepta lucris quosdam et prandiis inserunt subditicios ignobiles et obscuros.</p>
+
+                            </span>
+                            <hr class="clear">
+
+                            
+                            <div>
+                                <ul class="nav nav-tabs" role="tablist">
+                                    
+                                    <li role="presentation" class="active">
+                                        <a href="#request-delete-one-cat-responses-a187d805-0564-c12f-7817-c4356dcfc7ba" data-toggle="tab">
+                                            
+                                                Response
+                                            
+                                        </a>
+                                    </li>
+                                    
+                                </ul>
+                                <div class="tab-content">
+                                    
+                                    <div class="tab-pane active" id="request-delete-one-cat-responses-a187d805-0564-c12f-7817-c4356dcfc7ba">
+                                        <table class="table table-bordered">
+                                            <tr><th style="width: 20%;">Status</th><td>204 No Content</td></tr>
+                                            
+                                            <tr><th style="width: 20%;">Date</th><td>Tue, 23 Feb 2016 16:36:57 GMT</td></tr>
+                                            
+                                            
+                                        </table>
+                                    </div>
+                                    
+                                </div>
+                            </div>
+                            
+                                
+
+                                
+
+                            
+                            </div>
+
+                            <div class="col-md-5">
+                                <div class="code">
+                                    <small class="PATCH">Sample request</small>
+                                    <div class="panel panel-dark">
+                                        <div class="panel-heading">
+                                            <small>Delete one cat</small>
+                                        </div>
+                                        <div class="panel-body">
+                                            <div class="tab-content">
+                                                <div class="tab-pane active request-example-curl">
+                                                    <pre><code class="hljs curl">curl -X DELETE "http://{{domain}}/api/cats/{{catId}}"</code></pre>
+                                                </div>
+                                                <div class="tab-pane request-example-http">
+                                                    <pre><code class="hljs http">DELETE /api/cats/%7B%7BcatId%7D%7D HTTP/1.1
+Host: {{domain}}</code></pre>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                        <hr class="clear">
+                        
+
+                    
+
+                        
+                        <div class="request">
+                            <div class="col-md-7">
+                            <h4 id="request-get-zero-cats">
+                                <span class="strong GET">GET</span> Get zero cats
+                                <a href="#request-get-zero-cats"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+                            <input class="bg-warning form-control" disabled value="http://{{domain}}/api/cats" style="width:95%">
+                            <span class="markdown">
+                                <p>Quam ob rem cave Catoni anteponas ne istum quidem ipsum, quem Apollo, ut ais, sapientissimum iudicavit; huius enim facta, illius dicta laudantur. De me autem, ut iam cum utroque vestrum loquar, sic habetote.</p>
+
+                            </span>
+                            <hr class="clear">
+
+                            
+                                
+
+                                
+
+                            
+                            </div>
+
+                            <div class="col-md-5">
+                                <div class="code">
+                                    <small class="PATCH">Sample request</small>
+                                    <div class="panel panel-dark">
+                                        <div class="panel-heading">
+                                            <small>Get zero cats</small>
+                                        </div>
+                                        <div class="panel-body">
+                                            <div class="tab-content">
+                                                <div class="tab-pane active request-example-curl">
+                                                    <pre><code class="hljs curl">curl -X GET "http://{{domain}}/api/cats"</code></pre>
+                                                </div>
+                                                <div class="tab-pane request-example-http">
+                                                    <pre><code class="hljs http">GET /api/cats HTTP/1.1
+Host: {{domain}}</code></pre>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                        <hr class="clear">
+                        
+
+                    
+
+                </div>
+                
+                <div class="endpoints-group ">
+                    <h3 id="folder-dogs">
+                        Dogs
+                        <a href="#folder-dogs"><i class="glyphicon glyphicon-link"></i></a>
+                    </h3>
+                    <hr class="clear">
+
+                    <div class="col-md-7 doc no-padding"></div>
+
+                    
+
+                        
+                        <div class="request">
+                            <div class="col-md-7">
+                            <h4 id="request-get-one-dog">
+                                <span class="strong GET">GET</span> Get one dog
+                                <a href="#request-get-one-dog"><i class="glyphicon glyphicon-link"></i></a>
+                            </h4>
+                            <input class="bg-warning form-control" disabled value="http://{{domain}}/api/dogs/{{dogId}}" style="width:95%">
+                            <span class="markdown">
+                                <p>Ciliciam vero, quae Cydno amni exultat, Tarsus nobilitat, urbs perspicabilis hanc condidisse Perseus memoratur, Iovis filius et Danaes, vel certe ex Aethiopia profectus Sandan quidam nomine vir opulentus et nobilis et Anazarbus auctoris vocabulum referens, et Mopsuestia vatis illius domicilium Mopsi, quem a conmilitio Argonautarum cum aureo vellere direpto redirent, errore abstractum delatumque ad Africae litus mors repentina consumpsit, et ex eo cespite punico tecti manes eius heroici dolorum varietati medentur plerumque sospitales.</p>
+
+                            </span>
+                            <hr class="clear">
+
+                            
+                                
+
+                                
+
+                            
+                            </div>
+
+                            <div class="col-md-5">
+                                <div class="code">
+                                    <small class="PATCH">Sample request</small>
+                                    <div class="panel panel-dark">
+                                        <div class="panel-heading">
+                                            <small>Get one dog</small>
+                                        </div>
+                                        <div class="panel-body">
+                                            <div class="tab-content">
+                                                <div class="tab-pane active request-example-curl">
+                                                    <pre><code class="hljs curl">curl -X GET "http://{{domain}}/api/dogs/{{dogId}}"</code></pre>
+                                                </div>
+                                                <div class="tab-pane request-example-http">
+                                                    <pre><code class="hljs http">GET /api/dogs/%7B%7BdogId%7D%7D HTTP/1.1
+Host: {{domain}}</code></pre>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                        <hr class="clear">
+                        
+
+                    
+
+                </div>
+                
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-2.2.2.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/demos/markdown.html
+++ b/demos/markdown.html
@@ -1,0 +1,271 @@
+# Cats API
+
+## General notes
+
+Tu autem, Fanni, quod mihi tantum tribui dicis quantum ego nec adgnosco nec postulo, facis amice; sed, ut mihi videris, non recte iudicas de Catone; aut enim nemo, quod quidem magis credo, aut si quisquam, ille sapiens fuit. Quo modo, ut alia omittam, mortem filii tulit! memineram Paulum, videram Galum, sed hi in pueris, Cato in perfecto et spectato viro.
+
+Novitates autem si spem adferunt, ut tamquam in herbis non fallacibus fructus appareat, non sunt illae quidem repudiandae, vetustas tamen suo loco conservanda; maxima est enim vis vetustatis et consuetudinis. Quin in ipso equo, cuius modo feci mentionem, si nulla res impediat, nemo est, quin eo, quo consuevit, libentius utatur quam intractato et novo. Nec vero in hoc quod est animal, sed in iis etiam quae sunt inanima, consuetudo valet, cum locis ipsis delectemur, montuosis etiam et silvestribus, in quibus diutius commorati sumus.
+
+
+
+## API structures
+
+
+
+### Dog
+
+A greater animal
+
+<table class="table table-bordered">
+
+<tr>
+    <th>id</th>
+    <td>int</td>
+    <td>A unique identifier for the dog</td>
+</tr>
+
+<tr>
+    <th>color</th>
+    <td>string</td>
+    <td>The color of the dog</td>
+</tr>
+
+<tr>
+    <th>name</th>
+    <td>string</td>
+    <td>The name of the dog</td>
+</tr>
+
+</table>
+
+
+
+### Cat
+
+A great animal
+
+<table class="table table-bordered">
+
+<tr>
+    <th>id</th>
+    <td>int</td>
+    <td>A unique identifier for the cat</td>
+</tr>
+
+<tr>
+    <th>color</th>
+    <td>string</td>
+    <td>The color of the cat</td>
+</tr>
+
+<tr>
+    <th>name</th>
+    <td>string</td>
+    <td>The name of the cat</td>
+</tr>
+
+</table>
+
+
+
+
+
+## API Details
+
+
+### Cats
+
+Accedebant enim eius asperitati, ubi inminuta vel laesa amplitudo imperii dicebatur, et iracundae suspicionum quantitati proximorum cruentae blanditiae exaggerantium incidentia et dolere inpendio simulantium, si principis periclitetur vita, a cuius salute velut filo pendere statum orbis terrarum fictis vocibus exclamabant.
+
+Quod cum ita sit, paucae domus studiorum seriis cultibus antea celebratae nunc ludibriis ignaviae torpentis exundant, vocali sonu, perflabili tinnitu fidium resultantes. denique pro philosopho cantor et in locum oratoris doctor artium ludicrarum accitur et bybliothecis sepulcrorum ritu in perpetuum clausis organa fabricantur hydraulica, et lyrae ad speciem carpentorum ingentes tibiaeque et histrionici gestus instrumenta non levia.
+
+
+
+
+
+### Create a new cat
+
+Quae dum ita struuntur, indicatum est apud Tyrum indumentum regale textum occulte, incertum quo locante vel cuius usibus apparatum. ideoque rector provinciae tunc pater Apollinaris eiusdem nominis ut conscius ductus est aliique congregati sunt ex diversis civitatibus multi, qui atrocium criminum ponderibus urgebantur.
+
+#### Request
+
+<table>
+    <tr><th>Method</th><td>POST</td></tr>
+    <tr><th>URL</th><td>http://{{domain}}/api/cats</td></tr>
+</table>
+
+
+
+#### Response
+
+<table>
+    <tr><th>Code</th><td>201</td></tr>
+    <tr><th>Status</th><td>Created</td></tr>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+### Get all cats
+
+Sed si ille hac tam eximia fortuna propter utilitatem rei publicae frui non properat, ut omnia illa conficiat, quid ego, senator, facere debeo, quem, etiamsi ille aliud vellet, rei publicae consulere oporteret?
+
+#### Request
+
+<table>
+    <tr><th>Method</th><td>GET</td></tr>
+    <tr><th>URL</th><td>http://{{domain}}/api/cats</td></tr>
+</table>
+
+
+
+#### Response
+
+<table>
+    <tr><th>Code</th><td>200</td></tr>
+    <tr><th>Status</th><td>OK</td></tr>
+</table>
+
+
+**Example** :
+
+```
+[
+    {
+        "id": "56cc8a8228a4dbe55ca6e6ec",
+        "name": "Doctor Frankeinstein",
+        "color": "brown"
+    }
+]
+```
+
+
+
+
+
+
+
+
+
+
+### Get one cat
+
+Ciliciam vero, quae Cydno amni exultat, Tarsus nobilitat, urbs perspicabilis hanc condidisse Perseus memoratur, Iovis filius et Danaes, vel certe ex Aethiopia profectus Sandan quidam nomine vir opulentus et nobilis et Anazarbus auctoris vocabulum referens, et Mopsuestia vatis illius domicilium Mopsi, quem a conmilitio Argonautarum cum aureo vellere direpto redirent, errore abstractum delatumque ad Africae litus mors repentina consumpsit, et ex eo cespite punico tecti manes eius heroici dolorum varietati medentur plerumque sospitales.
+
+#### Request
+
+<table>
+    <tr><th>Method</th><td>GET</td></tr>
+    <tr><th>URL</th><td>http://{{domain}}/api/cats/{{catId}}</td></tr>
+</table>
+
+
+
+#### Response
+
+<table>
+    <tr><th>Code</th><td>200</td></tr>
+    <tr><th>Status</th><td>OK</td></tr>
+</table>
+
+
+**Example** :
+
+```
+{
+    "id": "56cc8a8228a4dbe55ca6e6ec",
+    "name": "Doctor Frankeinstein",
+    "color": "brown"
+}
+```
+
+
+
+
+
+
+
+
+
+
+### Delete one cat
+
+Homines enim eruditos et sobrios ut infaustos et inutiles vitant, eo quoque accedente quod et nomenclatores adsueti haec et talia venditare, mercede accepta lucris quosdam et prandiis inserunt subditicios ignobiles et obscuros.
+
+#### Request
+
+<table>
+    <tr><th>Method</th><td>DELETE</td></tr>
+    <tr><th>URL</th><td>http://{{domain}}/api/cats/{{catId}}</td></tr>
+</table>
+
+
+
+#### Response
+
+<table>
+    <tr><th>Code</th><td>204</td></tr>
+    <tr><th>Status</th><td>No Content</td></tr>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+### Get zero cats
+
+Quam ob rem cave Catoni anteponas ne istum quidem ipsum, quem Apollo, ut ais, sapientissimum iudicavit; huius enim facta, illius dicta laudantur. De me autem, ut iam cum utroque vestrum loquar, sic habetote.
+
+#### Request
+
+<table>
+    <tr><th>Method</th><td>GET</td></tr>
+    <tr><th>URL</th><td>http://{{domain}}/api/cats</td></tr>
+</table>
+
+
+
+
+
+
+
+
+### Dogs
+
+
+
+
+
+
+
+### Get one dog
+
+Ciliciam vero, quae Cydno amni exultat, Tarsus nobilitat, urbs perspicabilis hanc condidisse Perseus memoratur, Iovis filius et Danaes, vel certe ex Aethiopia profectus Sandan quidam nomine vir opulentus et nobilis et Anazarbus auctoris vocabulum referens, et Mopsuestia vatis illius domicilium Mopsi, quem a conmilitio Argonautarum cum aureo vellere direpto redirent, errore abstractum delatumque ad Africae litus mors repentina consumpsit, et ex eo cespite punico tecti manes eius heroici dolorum varietati medentur plerumque sospitales.
+
+#### Request
+
+<table>
+    <tr><th>Method</th><td>GET</td></tr>
+    <tr><th>URL</th><td>http://{{domain}}/api/dogs/{{dogId}}</td></tr>
+</table>
+
+
+
+
+
+
+
+


### PR DESCRIPTION
That way, users don't have to install and compile each theme to ensure the theme fulfill their needs. They can just browse an online version.

In order to keep this simple, we can use [rawgit.com](http://rawgit.com/) to serve each generated html files, accessible through links in the readme.

**Careful though, the current rawgit urls link to my fork (since the files do not exist yet here). After merging this, you should update those urls.**

Maybe we could add a script to generate those automatically instead of calling the binary by hand ?